### PR TITLE
Version 0.3.5 for Main components names in dist by rollup

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,8 @@ export default function CustomCommentInput() {
 For all Props, see direct link for Core Input Documentation: https://keiteldog.github.io/react-advanced-comment/path=/docs/react-advanced-comment-coreinput--docs
 
 #### 🐞 Bug Fixes & Improvements
+- 10 Dec 2023
+  - Keep main Components function name in distributed codes. `CommentInput, CoreInput, EmojiPicker, Mentions, Avatar`. Their name will appear in Shallow test for example as `<CommentInput ...>` instead of `<Component ... />`.
 - 9 Dec 2023
   - Add React 18 as peer dependencies
   - CommentInput root div has now a CSS className for styling

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keiteldog/react-advanced-comment",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "A React library for giving opinion with advanced comment supporting mentions and emoji in contenteditable div",
   "keywords": [
     "react",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -14,7 +14,7 @@ const plugins = [
   peerDepsExternal(),
   resolve(),
   commonjs(),
-  terser(),
+  terser({ keep_fnames : /CommentInput|CoreInput|EmojiPicker|Mentions|Avatar/ }),
   postcss(),
   svg({
     /**


### PR DESCRIPTION
Keep main components names in dist by rollup for `CommentInput, CoreInput, EmojiPicker, Mentions, Avatar`